### PR TITLE
Canvas Redis update and fix

### DIFF
--- a/canvas/Chart.yaml
+++ b/canvas/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,7 +26,7 @@ appVersion: 0.1.0
 
 dependencies:
   - name: redis
-    version: 16.4.0
+    version: 16.13.2
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: canvas-rce-api

--- a/canvas/values.yaml
+++ b/canvas/values.yaml
@@ -207,6 +207,7 @@ redis:
 
   commonConfiguration: |-
     maxmemory 50mb
+    maxmemory-policy allkeys-lru
     save ""
 
   auth:


### PR DESCRIPTION
- Update redis version
- Update Chart version
- Add `maxmemory-policy` to evict least recently used keys