### PR TITLE
Always add prometheus metric port env

### DIFF
--- a/atomic-app/Chart.yaml
+++ b/atomic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/atomic-app/templates/deployment-app.yaml
+++ b/atomic-app/templates/deployment-app.yaml
@@ -71,6 +71,9 @@ spec:
             {{- toYaml .Values.app.lifecycle | nindent 12 }}
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+          env:
+            - name: PROMETHEUS_EXPORTER_PORT
+              value: "9394"
       initContainers:
         - name: check-migrations
           securityContext:


### PR DESCRIPTION
We will use this env variable as a flag to enable metrics, so they can be disabled by default in non-prod environments.