### PR TITLE
Update default kubectl image

### DIFF
--- a/atomic-app/Chart.yaml
+++ b/atomic-app/Chart.yaml
@@ -21,7 +21,7 @@ version: 2.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "dev"
+appVersion: "prod"
 
 dependencies:
   - name: redis

--- a/atomic-app/values.yaml
+++ b/atomic-app/values.yaml
@@ -222,7 +222,7 @@ scheduledScaling:
   enabled: false
   image:
     repository: bitnami/kubectl
-    tag: 1.22
+    tag: 1.28
   cronjobs: []
     # - name: scale-up
     #   schedule: "0 11 * * 1-5"

--- a/catalyst/Chart.yaml
+++ b/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/catalyst/values.yaml
+++ b/catalyst/values.yaml
@@ -3,7 +3,7 @@ scheduledScaling:
   enabled: false
   image:
     repository: bitnami/kubectl
-    tag: 1.22
+    tag: 1.28
   cronjobs: []
     # - name: scale-up
     #   schedule: "0 11 * * 1-5"


### PR DESCRIPTION
- Using 1.28 as the default kubectl image since it's the newest compatible with our cluster.
- Update atomic_app app version to "prod".  Previously it was "dev" which was confusing.