### PR TITLE
RCE-API HPA update

### DIFF
--- a/canvas-rce-api/Chart.yaml
+++ b/canvas-rce-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canvas-rce-api/templates/hpa.yaml
+++ b/canvas-rce-api/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "canvas-rce-api.fullname" . }}
@@ -10,19 +10,16 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "canvas-rce-api.fullname" . }}
+{{- if .Values.autoscaling.minReplicas }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
+{{- end }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- with .Values.autoscaling.metrics }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/canvas-rce-api/values.yaml
+++ b/canvas-rce-api/values.yaml
@@ -78,8 +78,40 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
+  metrics: {}
+    # - type: Resource
+    #   resource:
+    #     name: cpu
+    #     target:
+    #       type: Utilization
+    #       averageUtilization: 80
+    # - type: Resource
+    #   resource:
+    #     name: memory
+    #     target:
+    #       type: Utilization
+    #       averageUtilization: 80
+  behavior: {}
+    # scaleUp:
+    #   stabilizationWindowSeconds: 0
+    #   policies:
+    #   - type: Percent
+    #     value: 100
+    #     periodSeconds: 15
+    #   - type: Pods
+    #     value: 4
+    #     periodSeconds: 15
+    #   selectPolicy: Max
+    # scaleDown:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Percent
+    #     value: 10
+    #     periodSeconds: 60
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 60
+    #   selectPolicy: Min
 
 nodeSelector: {}
 

--- a/canvas/Chart.lock
+++ b/canvas/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.0
+  version: 16.13.2
 - name: canvas-rce-api
   repository: file://../canvas-rce-api
-  version: 1.0.0
-digest: sha256:da4c8bcbcaba24a5134e4b82e13e08e3324ccd56f07785e864a8cb94f6e08c6c
-generated: "2022-09-30T22:31:48.634921535-04:00"
+  version: 2.0.0
+digest: sha256:c7a354b90eeb1563f388787a41959bed87ead1052599d318c1fe03f089f0ebdc
+generated: "2023-10-11T13:15:31.922069609-07:00"

--- a/canvas/Chart.yaml
+++ b/canvas/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,6 +30,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: canvas-rce-api
-    version: 1.0.0
+    version: 2.0.0
     repository: file://../canvas-rce-api
     condition: canvas-rce-api.enabled

--- a/canvas/templates/migrations.yaml
+++ b/canvas/templates/migrations.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "canvas.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never

--- a/canvas/templates/pre-migrations.yaml
+++ b/canvas/templates/pre-migrations.yaml
@@ -24,6 +24,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "canvas.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: Never

--- a/canvas/templates/serviceaccount.yaml
+++ b/canvas/templates/serviceaccount.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-20"
+    "helm.sh/resource-policy": keep
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/canvas/templates/serviceaccount.yaml
+++ b/canvas/templates/serviceaccount.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "canvas.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This updates the RCE-API chart to use the new HPA stuff, and bumps the Canvas chart to use the new RCE-API sub-chart as well