### PR TITLE
configure the catalyst lead worker to run the substitution processor by default

### DIFF
--- a/catalyst/Chart.yaml
+++ b/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/catalyst/templates/lead-worker-config.yaml
+++ b/catalyst/templates/lead-worker-config.yaml
@@ -8,5 +8,6 @@ data:
     run_scheduler = true
     run_slow_jobs = true
     run_regular_jobs = false
+    run_substitution_processor = true
     connect_cluster = true
     collect_db_metrics = true


### PR DESCRIPTION
opening as a draft until I verify the functionality on dev