### PR TITLE
New External Secrets

### DIFF
--- a/canvas-rce-api/Chart.yaml
+++ b/canvas-rce-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canvas-rce-api/templates/externalsecret.yaml
+++ b/canvas-rce-api/templates/externalsecret.yaml
@@ -1,5 +1,5 @@
-{{- if and ( .Capabilities.APIVersions.Has "kubernetes-client.io/v1" ) .Values.externalSecret.enabled -}}
-apiVersion: "kubernetes-client.io/v1"
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecret.enabled -}}
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: {{ .Values.configSecret }}

--- a/canvas/Chart.yaml
+++ b/canvas/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -30,6 +30,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: canvas-rce-api
-    version: 2.0.0
+    version: 3.0.0
     repository: file://../canvas-rce-api
     condition: canvas-rce-api.enabled

--- a/canvas/templates/externalsecret.yaml
+++ b/canvas/templates/externalsecret.yaml
@@ -1,5 +1,5 @@
-{{- if and ( .Capabilities.APIVersions.Has "kubernetes-client.io/v1" ) .Values.externalSecret.enabled -}}
-apiVersion: "kubernetes-client.io/v1"
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecret.enabled -}}
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: {{ .Values.configSecret }}

--- a/canvas/templates/externalsecretredis.yaml
+++ b/canvas/templates/externalsecretredis.yaml
@@ -1,5 +1,5 @@
-{{- if and ( .Capabilities.APIVersions.Has "kubernetes-client.io/v1" ) .Values.externalSecretRedis.enabled -}}
-apiVersion: "kubernetes-client.io/v1"
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecretRedis.enabled -}}
+apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
   name: {{ .Values.externalSecretRedis.name }}


### PR DESCRIPTION
This change is to reflect the new external secrets api in use and will require a change to the major chart version as it requires an entirely different operator to be installed and available in the cluster.