### PR TITLE
Update redis and add bundle exec

### DIFF
--- a/atomic-app/Chart.lock
+++ b/atomic-app/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.8.0
-digest: sha256:518bf88f2064784f3f233d6d3da1a8f11ed34dcb2f2e451c2bf3797e89177fdd
-generated: "2023-02-22T15:25:19.137647141-07:00"
+  version: 20.1.0
+digest: sha256:71c9263884ab0119ef79ccc8624ab32b14e5e57f7042661de406a412c97b6ad1
+generated: "2024-09-10T15:42:20.578929913-04:00"

--- a/atomic-app/Chart.yaml
+++ b/atomic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,6 +25,6 @@ appVersion: "prod"
 
 dependencies:
   - name: redis
-    version: 17.8.0
+    version: 20.1.0
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled

--- a/atomic-app/templates/deployment-app.yaml
+++ b/atomic-app/templates/deployment-app.yaml
@@ -38,6 +38,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: 
+            - bundle
+            - exec
             - puma
             - -t
             - "{{ .Values.app.pumaThreads }}"

--- a/atomic-app/templates/deployment-worker.yaml
+++ b/atomic-app/templates/deployment-worker.yaml
@@ -38,6 +38,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
+            - bundle
+            - exec
             - que
             - --worker-count
             - "{{ .Values.worker.queWorkers }}"


### PR DESCRIPTION
- Rails should be run with bundle exec in case bundler needs to override default gems.
- Update redis to latest chart

https://www.pivotaltracker.com/story/show/188253750