### PR TITLE
Add GitHub action workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,21 +42,3 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true
-
-      # # see https://github.com/helm/chart-releaser/issues/183
-      # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Push charts to GHCR
-      #   run: |
-      #     shopt -s nullglob
-      #     for pkg in .cr-release-packages/*; do
-      #       if [ -z "${pkg:-}" ]; then
-      #         break
-      #       fi
-      #       helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
-      #     done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release:
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.12.0
+
+        #FIXME: Self reference chart repo below from github instead of s3
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add atomicjolt https://atomicjolt-helm-charts.s3.amazonaws.com
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+
+      # # see https://github.com/helm/chart-releaser/issues/183
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Push charts to GHCR
+      #   run: |
+      #     shopt -s nullglob
+      #     for pkg in .cr-release-packages/*; do
+      #       if [ -z "${pkg:-}" ]; then
+      #         break
+      #       fi
+      #       helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+      #     done


### PR DESCRIPTION
I would like to do some testing, but apparently, the action has to be in place in the repo in order to actually test.  This places the action in the repo, with an option to run manually (`workflow_dispatch`) and that will allow selecting which branch to run this on.  The action won't work without other changes to the repo structure, so I expect that it will fail on the first merge/push to `main`