### PR TITLE
migration secrets

### DIFF
--- a/charts/atomic-app/Chart.yaml
+++ b/charts/atomic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atomic-app/templates/job.yaml
+++ b/charts/atomic-app/templates/job.yaml
@@ -45,7 +45,7 @@ spec:
       volumes:
         - name: secrets
           secret:
-            secretName: {{ .Values.configSecret }}
+            secretName: {{ .Values.migrationConfigSecret | default .Values.configSecret }}
         - name: credentials
           secret:
             secretName: {{ .Values.credentialsSecret }}

--- a/charts/atomic-app/values.yaml
+++ b/charts/atomic-app/values.yaml
@@ -13,7 +13,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 configSecret: ""
-migrationConfigSecret: null
+# Set this value if you want to use a different set of secrets for the migration job.
+# This is useful with the RLS multi-tenancy setup, where migrations run as a different user.
+# migrationConfigSecret: ""
 credentialsSecret: ""
 app:
   replicaCount: 1

--- a/charts/atomic-app/values.yaml
+++ b/charts/atomic-app/values.yaml
@@ -13,6 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 configSecret: ""
+migrationConfigSecret: null
 credentialsSecret: ""
 app:
   replicaCount: 1


### PR DESCRIPTION
Support using a separate secret for the config/k8s dir when running migrations.

This is specifically meant to support the new multi-tenancy model, where migrations run as a separate user.