### PR TITLE
Replace Bitnami Redis chart

### DIFF
--- a/charts/aa-datatable-engine/Chart.lock
+++ b/charts/aa-datatable-engine/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.1.0
-digest: sha256:71c9263884ab0119ef79ccc8624ab32b14e5e57f7042661de406a412c97b6ad1
-generated: "2024-09-16T13:31:43.258231478-04:00"
+  repository: https://groundhog2k.github.io/helm-charts/
+  version: 2.1.2
+digest: sha256:8f3662562db970a1fc375e5d60c95af5593959e60353f32bcdba7aaa850d1806
+generated: "2025-08-14T21:02:50.726651909-04:00"

--- a/charts/aa-datatable-engine/Chart.yaml
+++ b/charts/aa-datatable-engine/Chart.yaml
@@ -15,16 +15,16 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "prod"
 
 dependencies:
   - name: redis
-    version: 20.1.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.1.2
+    repository: https://groundhog2k.github.io/helm-charts/
     condition: redis.enabled

--- a/charts/aa-datatable-engine/UPGRADING_REDIS.md
+++ b/charts/aa-datatable-engine/UPGRADING_REDIS.md
@@ -1,0 +1,32 @@
+## Release 3.0.0 — Switch from Bitnami Redis Chart
+
+> **⚠️ Breaking Change** — This affects you if you're using Redis.
+
+### Secrets
+
+With the new Redis chart, the password is now set in a Redis configuration block inside a Secret.
+
+**Example:**
+
+```yaml
+redis.conf: |
+  requirepass secret1234
+  maxmemory 50mb
+```
+The chart supports an external secret for this secret as well.
+
+### Service name change:
+
+The new redis service is named 
+```
+my-app-redis
+```
+
+Previously it was named:
+```
+my-app-redis-master
+```
+
+Update the application configuration to match the new service name.
+
+

--- a/charts/aa-datatable-engine/templates/external-secret-config.yaml
+++ b/charts/aa-datatable-engine/templates/external-secret-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "app.fullname" . }}-secrets
+  name: {{ include "aa-datatable-engine.fullname" . }}-secrets
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"

--- a/charts/aa-datatable-engine/templates/external-secret-config.yaml
+++ b/charts/aa-datatable-engine/templates/external-secret-config.yaml
@@ -1,0 +1,20 @@
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecrets.config.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}-secrets
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+spec:
+  data:
+    {{- toYaml .Values.externalSecrets.config.data | nindent 4 }}
+  dataFrom:
+    {{- toYaml .Values.externalSecrets.config.dataFrom | nindent 4 }}
+  refreshInterval: {{ .Values.externalSecrets.config.refreshInterval }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecrets.config.secretStoreRef | nindent 4 }}
+  target:
+    {{- toYaml .Values.externalSecrets.config.target | nindent 4 }}
+    name:  {{ .Values.secretName }}
+{{- end }}

--- a/charts/aa-datatable-engine/templates/external-secret-redis.yaml
+++ b/charts/aa-datatable-engine/templates/external-secret-redis.yaml
@@ -1,0 +1,21 @@
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecrets.redis.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}-redis
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+spec:
+  data:
+    {{- toYaml .Values.externalSecrets.redis.data | nindent 4 }}
+  dataFrom:
+    {{- toYaml .Values.externalSecrets.redis.dataFrom | nindent 4 }}
+  refreshInterval: {{ .Values.externalSecrets.redis.refreshInterval }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecrets.redis.secretStoreRef | nindent 4 }}
+  target:
+    {{- toYaml .Values.externalSecrets.redis.target | nindent 4 }}
+    name:  {{ .Values.redis.extraSecretRedisConfigs }}
+
+{{- end }}

--- a/charts/aa-datatable-engine/templates/external-secret-redis.yaml
+++ b/charts/aa-datatable-engine/templates/external-secret-redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "app.fullname" . }}-redis
+  name: {{ include "aa-datatable-engine.fullname" . }}-redis
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"

--- a/charts/aa-datatable-engine/templates/networkpolicy.yaml
+++ b/charts/aa-datatable-engine/templates/networkpolicy.yaml
@@ -21,7 +21,7 @@ spec:
     - action: Allow
       destination:
         services:
-          name: {{ include "aa-datatable-engine.fullname" . }}-redis-master
+          name: {{ include "aa-datatable-engine.fullname" . }}-redis
           namespace: {{ .Release.Namespace }}
     {{- range .Values.networkPolicy.egressRules }}
     - {{ toYaml . | nindent 6 }}

--- a/charts/aa-datatable-engine/values.yaml
+++ b/charts/aa-datatable-engine/values.yaml
@@ -129,10 +129,10 @@ externalSecrets:
     # data:
     # - secretKey: REDIS_URL
     #   remoteRef:
-    #     key: /path/redis_url
+    #     key: /path/REDIS_URL
     # - secretKey: LEARNOSITY_SECRET
     #   remoteRef:
-    #     key: /path/learnosity_secret
+    #     key: /path/LEARNOSITY_SECRET
     secretStoreRef: {}
     # secretStoreRef:
     #   name: aws-ssm

--- a/charts/aa-datatable-engine/values.yaml
+++ b/charts/aa-datatable-engine/values.yaml
@@ -121,6 +121,7 @@ redis:
   redisConfig: |-
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
+    save ""
 
 externalSecrets:
   config:

--- a/charts/aa-datatable-engine/values.yaml
+++ b/charts/aa-datatable-engine/values.yaml
@@ -99,32 +99,62 @@ networkPolicy:
   egressRules: []
 
 redis:
-  enabled: false
-  architecture: standalone
-  commonConfiguration: |-
-    maxmemory 50mb
-    save ""
-  auth:
-    sentinel: false
-    existingSecret: aa-datatable-engine-redis
-    existingSecretPasswordKey: redis-password
-    usePasswordFiles: true
-  master:
-    podLabels:
-      redis-type: aa-datatable-engine
-    persistence:
-      enabled: false
-    resources:
-      requests:
-        memory: 100Mi
-      limits:
-        memory: 200Mi
-  replica:
-    replicaCount: 0
-    disableCommands:
-    persistence:
-      enabled: false
+  #image.registry: public.ecr.aws/docker/library
+  
+  # Additional configuration (e.g. password)
+  extraSecretRedisConfigs: redis-config
+
+  useDeploymentWhenNonHA: true
+
   metrics:
     enabled: true
-    serviceMonitor:
-      enabled: true
+
+  serviceMonitor:
+    enabled: true
+
+  resources:
+    requests:
+      memory: 100Mi
+    limits:
+      memory: 200Mi
+
+  redisConfig: |-
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+
+externalSecrets:
+  config:
+    enabled: false
+    data: []
+    # data:
+    # - secretKey: REDIS_URL
+    #   remoteRef:
+    #     key: /path/redis_url
+    # - secretKey: LEARNOSITY_SECRET
+    #   remoteRef:
+    #     key: /path/learnosity_secret
+    secretStoreRef: {}
+    # secretStoreRef:
+    #   name: aws-ssm
+    #   kind: ClusterSecretStore
+    refreshInterval: 2m
+    dataFrom: []
+    target: 
+      creationPolicy: Orphan
+      deletionPolicy: Retain
+  redis:
+    enabled: false
+    data: []
+    # data:
+    # - secretKey: redis.conf
+    #   remoteRef:
+    #     key: /path/redis.conf
+    secretStoreRef: {}
+    # secretStoreRef:
+    #   name: aws-ssm
+    #   kind: ClusterSecretStore
+    refreshInterval: 2m
+    dataFrom: []
+    target: 
+      creationPolicy: Orphan
+      deletionPolicy: Retain

--- a/charts/atomic-app/Chart.lock
+++ b/charts/atomic-app/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.1.0
-digest: sha256:71c9263884ab0119ef79ccc8624ab32b14e5e57f7042661de406a412c97b6ad1
-generated: "2024-09-10T15:42:20.578929913-04:00"
+  repository: https://groundhog2k.github.io/helm-charts/
+  version: 2.1.2
+digest: sha256:8f3662562db970a1fc375e5d60c95af5593959e60353f32bcdba7aaa850d1806
+generated: "2025-08-14T19:15:15.943374895-04:00"

--- a/charts/atomic-app/Chart.yaml
+++ b/charts/atomic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,6 +25,6 @@ appVersion: "prod"
 
 dependencies:
   - name: redis
-    version: 20.1.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.1.2
+    repository: https://groundhog2k.github.io/helm-charts/
     condition: redis.enabled

--- a/charts/atomic-app/UPGRADING_REDIS.md
+++ b/charts/atomic-app/UPGRADING_REDIS.md
@@ -1,0 +1,32 @@
+## Release 3.0.0 — Switch from Bitnami Redis Chart
+
+> **⚠️ Breaking Change** — This affects you if you're using Redis.
+
+### Secrets
+
+With the new Redis chart, the password is now set in a Redis configuration block inside a Secret.
+
+**Example:**
+
+```yaml
+redis.conf: |
+  requirepass secret1234
+  maxmemory 50mb
+```
+The chart supports an external secret for this secret as well.
+
+### Service name change:
+
+The new redis service is named 
+```
+my-app-redis
+```
+
+Previously it was named:
+```
+my-app-redis-master
+```
+
+Update the application configuration to match the new service name.
+
+

--- a/charts/atomic-app/templates/external-secret-redis.yaml
+++ b/charts/atomic-app/templates/external-secret-redis.yaml
@@ -1,0 +1,21 @@
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecrets.redis.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}-redis
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+spec:
+  data:
+    {{- toYaml .Values.externalSecrets.redis.data | nindent 4 }}
+  dataFrom:
+    {{- toYaml .Values.externalSecrets.redis.dataFrom | nindent 4 }}
+  refreshInterval: {{ .Values.externalSecrets.redis.refreshInterval }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecrets.redis.secretStoreRef | nindent 4 }}
+  target:
+    {{- toYaml .Values.externalSecrets.redis.target | nindent 4 }}
+    name:  {{ .Values.redis.extraSecretRedisConfigs }}
+
+{{- end }}

--- a/charts/atomic-app/values.yaml
+++ b/charts/atomic-app/values.yaml
@@ -246,33 +246,28 @@ scheduledScaling:
     #   appMinReplicas: 1
 
 redis:
-  enabled: false
-  architecture: standalone
-  commonConfiguration: |-
-    maxmemory 50mb
-    save ""
-  auth:
-    sentinel: false
-    existingSecret: redis
-    existingSecretPasswordKey: redis-password
-    usePasswordFiles: true
-  master:
-    persistence:
-      enabled: false
-    resources:
-      requests:
-        memory: 100Mi
-      limits:
-        memory: 200Mi
-  replica:
-    replicaCount: 0
-    disableCommands:
-    persistence:
-      enabled: false
+  #image.registry: public.ecr.aws/docker/library
+  
+  # Additional configuration (e.g. password)
+  extraSecretRedisConfigs: redis-config
+
+  useDeploymentWhenNonHA: true
+
   metrics:
     enabled: true
-    serviceMonitor:
-      enabled: true
+
+  serviceMonitor:
+    enabled: true
+
+  resources:
+    requests:
+      memory: 100Mi
+    limits:
+      memory: 200Mi
+
+  redisConfig: |-
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
 
 cronjobs:
   enabled: false
@@ -314,6 +309,23 @@ externalSecrets:
     # - secretKey: production.yml.enc
     #   remoteRef:
     #     key: /path/secrets.yml.enc
+    secretStoreRef: {}
+    # secretStoreRef:
+    #   name: aws-ssm
+    #   kind: ClusterSecretStore
+    refreshInterval: 2m
+    dataFrom: []
+    target: 
+      creationPolicy: Orphan
+      deletionPolicy: Retain
+  
+  redis:
+    enabled: false
+    data: []
+    # data:
+    # - secretKey: redis.conf
+    #   remoteRef:
+    #     key: /path/redis.conf
     secretStoreRef: {}
     # secretStoreRef:
     #   name: aws-ssm

--- a/charts/atomic-app/values.yaml
+++ b/charts/atomic-app/values.yaml
@@ -268,6 +268,7 @@ redis:
   redisConfig: |-
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
+    save ""
 
 cronjobs:
   enabled: false

--- a/charts/canvas/Chart.lock
+++ b/charts/canvas/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.13.2
+  repository: https://groundhog2k.github.io/helm-charts/
+  version: 2.1.2
 - name: canvas-rce-api
   repository: file://../canvas-rce-api
   version: 3.0.0
-digest: sha256:7c065337596552b6a3b2ab2c345fea5b9144e7cc5fc6bc7e2b065aeda964e41a
-generated: "2024-04-22T09:26:16.831092524-07:00"
+digest: sha256:5f9e41c1b8eeec3c2c59a2bd58b18ecd3ae549c8a544f21cd6df5ab06a3ed88f
+generated: "2025-08-14T21:07:54.656393759-04:00"

--- a/charts/canvas/Chart.yaml
+++ b/charts/canvas/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,8 +26,8 @@ appVersion: 0.1.0
 
 dependencies:
   - name: redis
-    version: 16.13.2
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.1.2
+    repository: https://groundhog2k.github.io/helm-charts/
     condition: redis.enabled
   - name: canvas-rce-api
     version: 3.0.0

--- a/charts/canvas/UPGRADING_REDIS.md
+++ b/charts/canvas/UPGRADING_REDIS.md
@@ -1,0 +1,31 @@
+## Release 3.0.0 — Switch from Bitnami Redis Chart
+
+> **⚠️ Breaking Change** — This affects you if you're using Redis.
+
+### Secrets
+
+With the new Redis chart, the password is now set in a Redis configuration block inside a Secret.
+
+**Example:**
+
+```yaml
+redis.conf: |
+  requirepass secret1234
+  maxmemory 50mb
+```
+
+### Service name change:
+
+The new redis service is named 
+```
+my-app-redis
+```
+
+Previously it was named:
+```
+my-app-redis-master
+```
+
+Update the application configuration to match the new service name.
+
+

--- a/charts/canvas/templates/externalsecretredis.yaml
+++ b/charts/canvas/templates/externalsecretredis.yaml
@@ -2,7 +2,7 @@
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
-  name: {{ .Values.externalSecretRedis.name }}
+  name: {{ .Values.redis.extraSecretRedisConfigs }}
   labels:
     {{- include "canvas.labels" . | nindent 4 }}
 {{- with .Values.externalSecretRedis.spec }}

--- a/charts/canvas/values.yaml
+++ b/charts/canvas/values.yaml
@@ -297,6 +297,7 @@ redis:
   redisConfig: |-
     rename-command FLUSHDB ""
     rename-command FLUSHALL ""
+    save ""
 
 s3mail:
   enabled: false

--- a/charts/canvas/values.yaml
+++ b/charts/canvas/values.yaml
@@ -275,37 +275,28 @@ canvas-rce-api:
       enabled: true
 
 redis:
-  enabled: true
-  architecture: standalone
+  #image.registry: public.ecr.aws/docker/library
+  
+  # Additional configuration (e.g. password)
+  extraSecretRedisConfigs: redis-config
 
-  commonConfiguration: |-
-    maxmemory 50mb
-    maxmemory-policy allkeys-lru
-    save ""
+  useDeploymentWhenNonHA: true
 
-  auth:
-    sentinel: false
-    existingSecret: redis
-    existingSecretPasswordKey: redis-password
-    usePasswordFiles: true
-  master:
-    resources:
-      requests:
-        memory: 100Mi
-      limits:
-        memory: 200Mi
-    disableCommands:
-      # TODO
-    persistence:
-      enabled: false
-  replica:
-    replicaCount: 0
-    disableCommands:
-      # TODO
-    persistence:
-      enabled: false
   metrics:
     enabled: true
+
+  serviceMonitor:
+    enabled: true
+
+  resources:
+    requests:
+      memory: 100Mi
+    limits:
+      memory: 200Mi
+
+  redisConfig: |-
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
 
 s3mail:
   enabled: false

--- a/charts/catalyst/Chart.lock
+++ b/charts/catalyst/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 17.8.0
-digest: sha256:518bf88f2064784f3f233d6d3da1a8f11ed34dcb2f2e451c2bf3797e89177fdd
-generated: "2023-07-13T11:20:23.469189-06:00"
+  repository: https://groundhog2k.github.io/helm-charts/
+  version: 2.1.2
+digest: sha256:8f3662562db970a1fc375e5d60c95af5593959e60353f32bcdba7aaa850d1806
+generated: "2025-08-14T22:18:04.353550784-04:00"

--- a/charts/catalyst/Chart.yaml
+++ b/charts/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,6 +25,6 @@ appVersion: "1.17.0"
 
 dependencies:
   - name: redis
-    version: 17.8.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 2.1.2
+    repository: https://groundhog2k.github.io/helm-charts/
     condition: redis.enabled

--- a/charts/catalyst/UPGRADING_REDIS.md
+++ b/charts/catalyst/UPGRADING_REDIS.md
@@ -1,0 +1,32 @@
+## Release 3.0.0 — Switch from Bitnami Redis Chart
+
+> **⚠️ Breaking Change** — This affects you if you're using Redis.
+
+### Secrets
+
+With the new Redis chart, the password is now set in a Redis configuration block inside a Secret.
+
+**Example:**
+
+```yaml
+redis.conf: |
+  requirepass secret1234
+  maxmemory 50mb
+```
+The chart supports an external secret for this secret as well.
+
+### Service name change:
+
+The new redis service is named 
+```
+my-app-redis
+```
+
+Previously it was named:
+```
+my-app-redis-master
+```
+
+Update the application configuration to match the new service name.
+
+

--- a/charts/catalyst/templates/external-secret-redis.yaml
+++ b/charts/catalyst/templates/external-secret-redis.yaml
@@ -1,0 +1,21 @@
+{{- if and ( .Capabilities.APIVersions.Has "external-secrets.io/v1beta1" ) .Values.externalSecrets.redis.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}-redis
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+spec:
+  data:
+    {{- toYaml .Values.externalSecrets.redis.data | nindent 4 }}
+  dataFrom:
+    {{- toYaml .Values.externalSecrets.redis.dataFrom | nindent 4 }}
+  refreshInterval: {{ .Values.externalSecrets.redis.refreshInterval }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecrets.redis.secretStoreRef | nindent 4 }}
+  target:
+    {{- toYaml .Values.externalSecrets.redis.target | nindent 4 }}
+    name:  {{ .Values.redis.extraSecretRedisConfigs }}
+
+{{- end }}

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -34,30 +34,44 @@ ajAppMonitoring:
   enabled: false
 
 redis:
-  enabled: false
-  architecture: standalone
-  commonConfiguration: |-
-    maxmemory 50mb
-    save ""
-  auth:
-    sentinel: false
-    existingSecret: redis
-    existingSecretPasswordKey: redis-password
-    usePasswordFiles: true
-  master:
-    persistence:
-      enabled: false
-    resources:
-      requests:
-        memory: 100Mi
-      limits:
-        memory: 200Mi
-  replica:
-    replicaCount: 0
-    disableCommands:
-    persistence:
-      enabled: false
+  #image.registry: public.ecr.aws/docker/library
+  
+  # Additional configuration (e.g. password)
+  extraSecretRedisConfigs: redis-config
+
+  useDeploymentWhenNonHA: true
+
   metrics:
     enabled: true
-    serviceMonitor:
-      enabled: true
+
+  serviceMonitor:
+    enabled: true
+
+  resources:
+    requests:
+      memory: 100Mi
+    limits:
+      memory: 200Mi
+
+  redisConfig: |-
+    rename-command FLUSHDB ""
+    rename-command FLUSHALL ""
+    save ""
+
+externalSecrets:
+  redis:
+    enabled: false
+    data: []
+    # data:
+    # - secretKey: redis.conf
+    #   remoteRef:
+    #     key: /path/redis.conf
+    secretStoreRef: {}
+    # secretStoreRef:
+    #   name: aws-ssm
+    #   kind: ClusterSecretStore
+    refreshInterval: 2m
+    dataFrom: []
+    target: 
+      creationPolicy: Orphan
+      deletionPolicy: Retain


### PR DESCRIPTION
Switch to groundhog2 Redis chart

This is a breaking change:

- The Redis secret is now set using a configuration block stored in a secret
- The Redis service is different and doesn't include the "-master" suffix
- Any redis helm values might need updating

- https://github.com/atomicjolt/terraform/issues/365