### PR TITLE
Support both calico 3.28 and 3.29

### DIFF
--- a/charts/aa-datatable-engine/Chart.yaml
+++ b/charts/aa-datatable-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/aa-datatable-engine/templates/networkpolicy-calico28.yaml
+++ b/charts/aa-datatable-engine/templates/networkpolicy-calico28.yaml
@@ -1,11 +1,13 @@
 {{- if and ( .Capabilities.APIVersions.Has "projectcalico.org/v3" ) .Values.networkPolicy.enabled -}}
-{{- if .Capabilities.APIVersions.Has "projectcalico.org/v3/Tier" -}}
+{{- if not ( .Capabilities.APIVersions.Has "projectcalico.org/v3/Tier" ) -}}
+{{/*
+ NetworkPolicy for calico <= 3.28
+*/}}
 apiVersion: projectcalico.org/v3
 kind: NetworkPolicy
 metadata:
-  name: default.{{ include "aa-datatable-engine.name" . }}
+  name: {{ include "aa-datatable-engine.name" . }}
 spec:
-  tier: default
   selector: app.kubernetes.io/name == '{{ include "aa-datatable-engine.name" . }}'
   {{- if gt (len .Values.networkPolicy.ingressRules) 0 }}
   ingress:


### PR DESCRIPTION
Calico 3.29 introduced a breaking change to the way NetworkPolicies are defined. This change supports both 3.29 and the older 3.28.