### PR TITLE
Add support for custom pod labels

### DIFF
--- a/charts/atomic-app/Chart.yaml
+++ b/charts/atomic-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.1
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atomic-app/templates/deployment-app.yaml
+++ b/charts/atomic-app/templates/deployment-app.yaml
@@ -34,6 +34,9 @@ spec:
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
         type: app
+        {{- with .Values.app.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/atomic-app/templates/deployment-worker.yaml
+++ b/charts/atomic-app/templates/deployment-worker.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
         type: worker
+        {{- with .Values.worker.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/atomic-app/templates/job.yaml
+++ b/charts/atomic-app/templates/job.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         {{- include "app.selectorLabels" . | nindent 8 }}
         type: migration
+        {{- with .Values.app.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/atomic-app/templates/rake-cronjobs.yaml
+++ b/charts/atomic-app/templates/rake-cronjobs.yaml
@@ -13,6 +13,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- with $top.Values.cronjobs.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           serviceAccountName: {{ include "app.serviceAccountName" $top }}
           restartPolicy: OnFailure

--- a/charts/atomic-app/templates/scaling-cronjobs.yaml
+++ b/charts/atomic-app/templates/scaling-cronjobs.yaml
@@ -13,6 +13,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- with $top.Values.scheduledScaling.labels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         spec:
           serviceAccountName: {{ template "app.fullname" $top }}-scaler
           restartPolicy: OnFailure


### PR DESCRIPTION
We want this to be able to apply calico policies to pods.