### PR TITLE
Add optional unbound DNS caching sidecar to worker deployment

### DIFF
--- a/charts/catalyst/Chart.yaml
+++ b/charts/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/catalyst/templates/worker-deployment.yaml
+++ b/charts/catalyst/templates/worker-deployment.yaml
@@ -37,6 +37,22 @@ spec:
             mountPath: /shared
         resources:
 {{ .Values.workerResources | toYaml | indent 10 }}
+      {{- if and .Values.dnsSidecar.enabled .Values.dnsSidecar.metrics.enabled }}
+      - name: unbound-exporter
+        image: {{ .Values.dnsSidecar.metrics.image }}
+        args:
+        - --unbound.host=unix://{{ .Values.dnsSidecar.metrics.controlSocket }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.dnsSidecar.metrics.port }}
+        volumeMounts:
+        - name: unbound-socket
+          mountPath: {{ .Values.dnsSidecar.metrics.controlSocket | dir }}
+        {{- if .Values.dnsSidecar.metrics.resources }}
+        resources:
+{{ .Values.dnsSidecar.metrics.resources | toYaml | indent 10 }}
+        {{- end }}
+      {{- end }}
 {{ if .Values.workerAffinity }}
       {{- with .Values.workerAffinity }}
       affinity:
@@ -53,6 +69,23 @@ spec:
         type: "{{ .Values.workerNodeSelector }}"
 {{ end }}
       initContainers:
+      {{- if .Values.dnsSidecar.enabled }}
+      - name: unbound
+        image: {{ .Values.dnsSidecar.image }}
+        restartPolicy: Always
+        volumeMounts:
+        - name: dns-config
+          mountPath: /etc/unbound/unbound.conf
+          subPath: unbound.conf
+        {{- if .Values.dnsSidecar.metrics.enabled }}
+        - name: unbound-socket
+          mountPath: {{ .Values.dnsSidecar.metrics.controlSocket | dir }}
+        {{- end }}
+        {{- if .Values.dnsSidecar.resources }}
+        resources:
+{{ .Values.dnsSidecar.resources | toYaml | indent 10 }}
+        {{- end }}
+      {{- end }}
       - name: check-migrations
         image: {{ .Values.image }}
         imagePullPolicy: IfNotPresent
@@ -70,10 +103,24 @@ spec:
       # Workers need to be given enough time to gracefully quit after finishing
       # current jobs
       terminationGracePeriodSeconds: 60
+      {{- if .Values.dnsSidecar.enabled }}
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+        - "127.0.0.1"
+        searches:
+        - {{ .Release.Namespace }}.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+        options:
+        - name: ndots
+          value: "2"
+      {{- else }}
       dnsConfig:
         options:
         - name: ndots
           value: "2"
+      {{- end }}
       volumes:
       - name: config-volume
         projected:
@@ -85,3 +132,12 @@ spec:
       - name: "shared-storage"
         persistentVolumeClaim:
           claimName: "shared-storage"
+      {{- if .Values.dnsSidecar.enabled }}
+      - name: dns-config
+        configMap:
+          name: catalyst-worker-dns-config
+      {{- end }}
+      {{- if and .Values.dnsSidecar.enabled .Values.dnsSidecar.metrics.enabled }}
+      - name: unbound-socket
+        emptyDir: {}
+      {{- end }}

--- a/charts/catalyst/templates/worker-deployment.yaml
+++ b/charts/catalyst/templates/worker-deployment.yaml
@@ -40,6 +40,9 @@ spec:
       {{- if and .Values.dnsSidecar.enabled .Values.dnsSidecar.metrics.enabled }}
       - name: unbound-exporter
         image: {{ .Values.dnsSidecar.metrics.image }}
+        securityContext:
+          runAsUser: 100
+          runAsGroup: 101
         args:
         - --unbound.host=unix://{{ .Values.dnsSidecar.metrics.controlSocket }}
         ports:

--- a/charts/catalyst/templates/worker-deployment.yaml
+++ b/charts/catalyst/templates/worker-deployment.yaml
@@ -41,8 +41,10 @@ spec:
       - name: unbound-exporter
         image: {{ .Values.dnsSidecar.metrics.image }}
         securityContext:
-          runAsUser: 100
-          runAsGroup: 101
+          # klutchell/unbound uses 101:102
+          # alpine/unbound uses 100:101
+          runAsUser: 101
+          runAsGroup: 102
         args:
         - --unbound.host=unix://{{ .Values.dnsSidecar.metrics.controlSocket }}
         ports:

--- a/charts/catalyst/templates/worker-dns-sidecar-config.yaml
+++ b/charts/catalyst/templates/worker-dns-sidecar-config.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.dnsSidecar.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalyst-worker-dns-config
+data:
+  unbound.conf: |
+{{ tpl .Values.dnsSidecar.unboundConf . | indent 4 }}
+{{- end }}

--- a/charts/catalyst/templates/worker-dns-sidecar-service-monitor.yaml
+++ b/charts/catalyst/templates/worker-dns-sidecar-service-monitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.dnsSidecar.enabled .Values.dnsSidecar.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalyst-worker-unbound
+  labels:
+    metrics: catalyst-unbound
+spec:
+  selector:
+    app: catalyst-worker
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.dnsSidecar.metrics.port }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: catalyst-unbound-monitoring
+  labels:
+    release: metrics
+spec:
+  selector:
+    matchLabels:
+      metrics: catalyst-unbound
+  endpoints:
+  - port: metrics
+    interval: 30s
+{{- end }}

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -113,8 +113,7 @@ dnsSidecar:
   clusterDnsIP: "10.96.0.10"
   # Upstream forwarders for the catch-all zone (".").
   forwarders:
-  - "1.1.1.2"
-  - "1.0.0.2"
+  - "169.254.169.253" # AWS Route53 dns
   # RRset cache holds individual resource records; msg cache holds full responses.
   # rrset-cache-size should generally be 2x msg-cache-size.
   msgCacheSize: "16m"

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -106,7 +106,7 @@ dnsSidecar:
   enabled: false
   # Requires Kubernetes 1.29+ for native sidecar support (init container with restartPolicy: Always).
   # The sidecar starts before all init containers, providing DNS caching for every container in the pod.
-  image: klutchell/unbound:latest
+  image: ghcr.io/klutchell/unbound:latest
   resources: {}
   # ClusterIP of the kube-dns service in your cluster.
   # Retrieve with: kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}'
@@ -121,7 +121,7 @@ dnsSidecar:
   rrsetCacheSize: "32m"
   metrics:
     enabled: false
-    image: ghcr.io/kumina/unbound_exporter:latest
+    image: cyb3rjak3/unbound-exporter:0.5.0
     port: 9167
     controlSocket: /run/unbound/unbound.ctl
     resources: {}

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -106,7 +106,7 @@ dnsSidecar:
   enabled: false
   # Requires Kubernetes 1.29+ for native sidecar support (init container with restartPolicy: Always).
   # The sidecar starts before all init containers, providing DNS caching for every container in the pod.
-  image: ghcr.io/klutchell/unbound:latest
+  image: ghcr.io/klutchell/unbound:1.24.2
   resources: {}
   # ClusterIP of the kube-dns service in your cluster.
   # Retrieve with: kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}'
@@ -121,7 +121,9 @@ dnsSidecar:
   rrsetCacheSize: "32m"
   metrics:
     enabled: false
-    image: cyb3rjak3/unbound-exporter:0.5.0
+    # This isn't a common image, so locking to a sha256
+    # I used: podman inspect cyb3rjak3/unbound-exporter:0.5.0 --format '{{.Digest}}'
+    image: cyb3rjak3/unbound-exporter:0.5.0@sha256:e4973d36ba6485e5e9378e6d3e72677c177d69a62a11c9da549a71ff9904e09f
     port: 9167
     controlSocket: /run/unbound/unbound.ctl
     resources: {}

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -1,3 +1,4 @@
+elasticsearchWhitelistLabels: {}
 scheduledScaling:
   # all times are UTC
   enabled: false
@@ -100,3 +101,56 @@ externalSecrets:
     target: 
       creationPolicy: Orphan
       deletionPolicy: Retain
+
+dnsSidecar:
+  enabled: false
+  # Requires Kubernetes 1.29+ for native sidecar support (init container with restartPolicy: Always).
+  # The sidecar starts before all init containers, providing DNS caching for every container in the pod.
+  image: klutchell/unbound:latest
+  resources: {}
+  # ClusterIP of the kube-dns service in your cluster.
+  # Retrieve with: kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}'
+  clusterDnsIP: "10.96.0.10"
+  # Upstream forwarders for the catch-all zone (".").
+  forwarders:
+  - "1.1.1.2"
+  - "1.0.0.2"
+  # RRset cache holds individual resource records; msg cache holds full responses.
+  # rrset-cache-size should generally be 2x msg-cache-size.
+  msgCacheSize: "16m"
+  rrsetCacheSize: "32m"
+  metrics:
+    enabled: false
+    image: ghcr.io/kumina/unbound_exporter:latest
+    port: 9167
+    controlSocket: /run/unbound/unbound.ctl
+    resources: {}
+  # Full unbound.conf content. Supports Helm template expressions (evaluated via tpl).
+  unboundConf: |
+    server:
+      interface: 127.0.0.1
+      port: 53
+      do-daemonize: no
+      access-control: 127.0.0.1 allow
+      msg-cache-size: {{ .Values.dnsSidecar.msgCacheSize }}
+      rrset-cache-size: {{ .Values.dnsSidecar.rrsetCacheSize }}
+      # Allow resolving K8s internal names by forwarding to CoreDNS
+      local-zone: "cluster.local." transparent
+    {{- if .Values.dnsSidecar.metrics.enabled }}
+    remote-control:
+      control-enable: yes
+      control-interface: {{ .Values.dnsSidecar.metrics.controlSocket }}
+      control-use-cert: no
+    {{- end }}
+
+    # FORWARDING RULES
+    forward-zone:
+      name: "cluster.local."
+      forward-addr: {{ .Values.dnsSidecar.clusterDnsIP }}
+
+    forward-zone:
+      name: "."
+      {{- range .Values.dnsSidecar.forwarders }}
+      forward-addr: {{ . }}
+      {{- end }}
+

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -106,7 +106,7 @@ dnsSidecar:
   enabled: false
   # Requires Kubernetes 1.29+ for native sidecar support (init container with restartPolicy: Always).
   # The sidecar starts before all init containers, providing DNS caching for every container in the pod.
-  image: alpinelinux/unbound:latest
+  image: klutchell/unbound:v1.25.1
   resources: {}
   # ClusterIP of the kube-dns service in your cluster.
   # Retrieve with: kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}'

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -106,18 +106,22 @@ dnsSidecar:
   enabled: false
   # Requires Kubernetes 1.29+ for native sidecar support (init container with restartPolicy: Always).
   # The sidecar starts before all init containers, providing DNS caching for every container in the pod.
-  image: ghcr.io/klutchell/unbound:1.24.2
+  image: alpinelinux/unbound:latest
   resources: {}
   # ClusterIP of the kube-dns service in your cluster.
   # Retrieve with: kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}'
   clusterDnsIP: "10.96.0.10"
+  # Additional DNS zones to forward to cluster DNS (CoreDNS) instead of the catch-all forwarder.
+  # Useful for AWS RDS endpoints and other AWS service domains that CoreDNS can resolve via
+  # Route53 private hosted zones or NodeLocal DNSCache.
+  # Example: ["rds.amazonaws.com.", "amazonaws.com."]
+  clusterForwardZones:
+  - "amazonaws.com."
   # Upstream forwarders for the catch-all zone (".").
   forwarders:
   - "169.254.169.253" # AWS Route53 dns
   # Enable DNS-over-TLS for the catch-all forward zone.
   forwardTlsUpstream: false
-  # Enable DNS-over-SSL for the catch-all forward zone.
-  forwardSslUpstream: false
   # RRset cache holds individual resource records; msg cache holds full responses.
   # rrset-cache-size should generally be 2x msg-cache-size.
   msgCacheSize: "16m"
@@ -134,13 +138,20 @@ dnsSidecar:
   unboundConf: |
     server:
       interface: 127.0.0.1
+      do-ip4: yes
+      do-ip6: no
       port: 53
+      verbosity: 2
+      use-syslog: no
       do-daemonize: no
-      access-control: 127.0.0.1 allow
+      access-control: 127.0.0.1/8 allow
+      tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
+      so-sndbuf: 0
       msg-cache-size: {{ .Values.dnsSidecar.msgCacheSize }}
       rrset-cache-size: {{ .Values.dnsSidecar.rrsetCacheSize }}
       # Allow resolving K8s internal names by forwarding to CoreDNS
       local-zone: "cluster.local." transparent
+      extended-statistics: yes
     {{- if .Values.dnsSidecar.metrics.enabled }}
     remote-control:
       control-enable: yes
@@ -152,12 +163,16 @@ dnsSidecar:
     forward-zone:
       name: "cluster.local."
       forward-addr: {{ .Values.dnsSidecar.clusterDnsIP }}
+    {{- range .Values.dnsSidecar.clusterForwardZones }}
+
+    forward-zone:
+      name: "{{ . }}"
+      forward-addr: {{ $.Values.dnsSidecar.clusterDnsIP }}
+    {{- end }}
 
     forward-zone:
       name: "."
       forward-tls-upstream: {{ ternary "yes" "no" .Values.dnsSidecar.forwardTlsUpstream }}
-      forward-ssl-upstream: {{ ternary "yes" "no" .Values.dnsSidecar.forwardSslUpstream }}
       {{- range .Values.dnsSidecar.forwarders }}
       forward-addr: {{ . }}
       {{- end }}
-

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -116,6 +116,7 @@ dnsSidecar:
   - "169.254.169.253" # AWS Route53 dns
   # Enable DNS-over-TLS for the catch-all forward zone.
   forwardTlsUpstream: false
+  # Enable DNS-over-SSL for the catch-all forward zone.
   forwardSslUpstream: false
   # RRset cache holds individual resource records; msg cache holds full responses.
   # rrset-cache-size should generally be 2x msg-cache-size.

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -114,6 +114,9 @@ dnsSidecar:
   # Upstream forwarders for the catch-all zone (".").
   forwarders:
   - "169.254.169.253" # AWS Route53 dns
+  # Enable DNS-over-TLS for the catch-all forward zone.
+  forwardTlsUpstream: false
+  forwardSslUpstream: false
   # RRset cache holds individual resource records; msg cache holds full responses.
   # rrset-cache-size should generally be 2x msg-cache-size.
   msgCacheSize: "16m"
@@ -151,6 +154,8 @@ dnsSidecar:
 
     forward-zone:
       name: "."
+      forward-tls-upstream: {{ ternary "yes" "no" .Values.dnsSidecar.forwardTlsUpstream }}
+      forward-ssl-upstream: {{ ternary "yes" "no" .Values.dnsSidecar.forwardSslUpstream }}
       {{- range .Values.dnsSidecar.forwarders }}
       forward-addr: {{ . }}
       {{- end }}


### PR DESCRIPTION
- Unbound runs as a K8s 1.29+ native sidecar (initContainer with restartPolicy: Always), starting before check-migrations so DNS is available to all containers
- dnsPolicy switches to None with 127.0.0.1 as nameserver when enabled
- cluster.local forwarded to configurable clusterDnsIP; catch-all zone forwarded to a configurable forwarders list
- msg/rrset cache sizes are top-level values
- Optional Prometheus exporter (kumina/unbound_exporter) with control socket on a Unix domain socket shared via emptyDir volume