### PR TITLE
Add argocd hooks for reactor

### DIFF
--- a/charts/atomic-reactor/Chart.yaml
+++ b/charts/atomic-reactor/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atomic-reactor/templates/external-secret-env.yaml
+++ b/charts/atomic-reactor/templates/external-secret-env.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+    "argocd.argoproj.io/sync-wave": "-10"
 spec:
   data:
     {{- toYaml .Values.externalSecrets.env.data | nindent 4 }}

--- a/charts/atomic-reactor/templates/external-secret-redis.yaml
+++ b/charts/atomic-reactor/templates/external-secret-redis.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+    "argocd.argoproj.io/sync-wave": "-10"
 spec:
   data:
     {{- toYaml .Values.externalSecrets.redis.data | nindent 4 }}
@@ -25,6 +26,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+    "argocd.argoproj.io/sync-wave": "-10"
 spec:
   data:
     {{- toYaml .Values.externalSecrets.redis.data | nindent 4 }}

--- a/charts/atomic-reactor/templates/job.yaml
+++ b/charts/atomic-reactor/templates/job.yaml
@@ -9,6 +9,9 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/sync-wave": "-5"
+    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
 spec:
   template:
     metadata:

--- a/charts/atomic-reactor/templates/serviceaccount.yaml
+++ b/charts/atomic-reactor/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+    "argocd.argoproj.io/sync-wave": "-10"
     {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
With the change, the migration job is a hook, but the external secrets and service accounts are regular resource with an earlier sync wave.