### PR TITLE
Make unbound log verbosity configurable

### DIFF
--- a/charts/catalyst/Chart.yaml
+++ b/charts/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -122,6 +122,8 @@ dnsSidecar:
   - "169.254.169.253" # AWS Route53 dns
   # Enable DNS-over-TLS for the catch-all forward zone.
   forwardTlsUpstream: false
+  # Unbound log verbosity level (0=minimal, 1=operational, 2=detailed, 3+=debug).
+  logVerbosity: 1
   # RRset cache holds individual resource records; msg cache holds full responses.
   # rrset-cache-size should generally be 2x msg-cache-size.
   msgCacheSize: "16m"
@@ -141,7 +143,7 @@ dnsSidecar:
       do-ip4: yes
       do-ip6: no
       port: 53
-      verbosity: 2
+      verbosity: {{ .Values.dnsSidecar.logVerbosity }}
       use-syslog: no
       do-daemonize: no
       access-control: 127.0.0.1/8 allow


### PR DESCRIPTION
## Summary

- Adds `dnsSidecar.logVerbosity` value (default `1`) to control unbound log verbosity
- Replaces hardcoded `verbosity: 2` in the default `unboundConf` with a template reference to the new value
- Bumps chart to 2.3.1

## Test plan

- [ ] Deploy with default `logVerbosity: 1` and verify unbound logs at operational level
- [ ] Override `logVerbosity: 2` and verify more detailed logs appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)