### PR TITLE
catalyst: split image into repository/tag (breaking)

### DIFF
--- a/charts/catalyst/CLAUDE.md
+++ b/charts/catalyst/CLAUDE.md
@@ -36,7 +36,7 @@ helm template my-release . -f my-values.yaml --debug
 
 ## Architecture: Deployment Types
 
-All three deployments run the same container image (`.Values.image`) but are differentiated by their ConfigMap-injected `specific.toml`, which controls which Catalyst subsystems activate.
+All three deployments run the same container image (`.Values.image.repository`:`.Values.image.tag`, tag defaulting to `.Chart.AppVersion`) but are differentiated by their ConfigMap-injected `specific.toml`, which controls which Catalyst subsystems activate.
 
 | Deployment | Config | Scheduler | Regular jobs | Slow jobs | Phoenix endpoints |
 |---|---|---|---|---|---|
@@ -81,7 +81,7 @@ When `scheduledScaling.enabled: true`, the chart creates CronJobs that use `kube
 ## Key Values
 
 Required values that have no defaults and must be provided:
-- `image` — container image for all Catalyst deployments
+- `image.repository` — container image repository for all Catalyst deployments (`image.tag` is optional and defaults to the chart `appVersion`)
 - `hostname` — used in the ALB Ingress rule and TLS host
 - `appReplicaCount`, `workerReplicaCount` — replica counts
 - `appResources`, `workerResources`, `leadWorkerResources` — resource requests/limits

--- a/charts/catalyst/CLAUDE.md
+++ b/charts/catalyst/CLAUDE.md
@@ -36,7 +36,7 @@ helm template my-release . -f my-values.yaml --debug
 
 ## Architecture: Deployment Types
 
-All three deployments run the same container image (`.Values.image.repository`:`.Values.image.tag`, tag defaulting to `.Chart.AppVersion`) but are differentiated by their ConfigMap-injected `specific.toml`, which controls which Catalyst subsystems activate.
+All three deployments run the same container image (`.Values.image.repository`:`.Values.image.tag`) but are differentiated by their ConfigMap-injected `specific.toml`, which controls which Catalyst subsystems activate.
 
 | Deployment | Config | Scheduler | Regular jobs | Slow jobs | Phoenix endpoints |
 |---|---|---|---|---|---|
@@ -81,7 +81,7 @@ When `scheduledScaling.enabled: true`, the chart creates CronJobs that use `kube
 ## Key Values
 
 Required values that have no defaults and must be provided:
-- `image.repository` — container image repository for all Catalyst deployments (`image.tag` is optional and defaults to the chart `appVersion`)
+- `image.repository`, `image.tag` — container image repository and tag for all Catalyst deployments (both required; there is no `appVersion` fallback for `tag`)
 - `hostname` — used in the ALB Ingress rule and TLS host
 - `appReplicaCount`, `workerReplicaCount` — replica counts
 - `appResources`, `workerResources`, `leadWorkerResources` — resource requests/limits

--- a/charts/catalyst/Chart.yaml
+++ b/charts/catalyst/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/catalyst/templates/app-deployment.yaml
+++ b/charts/catalyst/templates/app-deployment.yaml
@@ -24,12 +24,14 @@ spec:
     metadata:
       labels:
         app: catalyst-app
+{{- if .Values.elasticsearchWhitelistLabels }}
 {{ .Values.elasticsearchWhitelistLabels | toYaml | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: catalyst
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -61,7 +63,7 @@ spec:
 {{ .Values.appResources | toYaml | indent 10 }}
       initContainers:
       - name: check-migrations
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ["/opt/catalyst/bin/catalyst", "eval", "Catalyst.ReleaseTasks.check_migrations(nil)"]
         env:

--- a/charts/catalyst/templates/cron-jobs.yaml
+++ b/charts/catalyst/templates/cron-jobs.yaml
@@ -17,7 +17,7 @@ spec:
           serviceAccountName: {{ $top.Values.serviceAccount.name }}
           containers:
           - name: catalyst
-            image: {{ $top.Values.image }}
+            image: "{{ $top.Values.image.repository }}:{{ $top.Values.image.tag }}"
             imagePullPolicy: IfNotPresent
             command: ["/opt/catalyst/bin/catalyst", "eval", "{{ $cronjob.command }}"]
             env:

--- a/charts/catalyst/templates/dap-worker-deployment.yaml
+++ b/charts/catalyst/templates/dap-worker-deployment.yaml
@@ -14,12 +14,14 @@ spec:
       labels:
         app: catalyst-dap-worker
         cluster: catalyst-workers
+{{- if .Values.elasticsearchWhitelistLabels }}
 {{ .Values.elasticsearchWhitelistLabels | toYaml | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: catalyst
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         env:
           - name: REPLACE_OS_VARS
@@ -43,7 +45,7 @@ spec:
 {{ end }}
       initContainers:
       - name: check-migrations
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ["/opt/catalyst/bin/catalyst", "eval", "Catalyst.ReleaseTasks.check_migrations(nil)"]
         env:

--- a/charts/catalyst/templates/lead-worker-deployment.yaml
+++ b/charts/catalyst/templates/lead-worker-deployment.yaml
@@ -17,12 +17,14 @@ spec:
       labels:
         app: catalyst-lead-worker
         cluster: catalyst-workers
+{{- if .Values.elasticsearchWhitelistLabels }}
 {{ .Values.elasticsearchWhitelistLabels | toYaml | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: catalyst
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         env:
           - name: REPLACE_OS_VARS
@@ -46,7 +48,7 @@ spec:
 {{ end }}
       initContainers:
       - name: check-migrations
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ["/opt/catalyst/bin/catalyst", "eval", "Catalyst.ReleaseTasks.check_migrations(nil)"]
         env:

--- a/charts/catalyst/templates/migrations.yaml
+++ b/charts/catalyst/templates/migrations.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: migrations
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ["/opt/catalyst/bin/catalyst", "eval", "Catalyst.ReleaseTasks.migrate(nil)"]
         volumeMounts:

--- a/charts/catalyst/templates/worker-deployment.yaml
+++ b/charts/catalyst/templates/worker-deployment.yaml
@@ -16,12 +16,14 @@ spec:
       labels:
         app: catalyst-worker
         cluster: catalyst-workers
+{{- if .Values.elasticsearchWhitelistLabels }}
 {{ .Values.elasticsearchWhitelistLabels | toYaml | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: catalyst
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         env:
           - name: REPLACE_OS_VARS
@@ -92,7 +94,7 @@ spec:
         {{- end }}
       {{- end }}
       - name: check-migrations
-        image: {{ .Values.image }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         command: ["/opt/catalyst/bin/catalyst", "eval", "Catalyst.ReleaseTasks.check_migrations(nil)"]
         env:

--- a/charts/catalyst/values.yaml
+++ b/charts/catalyst/values.yaml
@@ -1,3 +1,9 @@
+# Container image for all Catalyst deployments (app, worker, lead-worker),
+# migrations, and cronjobs.
+image:
+  repository: ""
+  tag: ""
+
 elasticsearchWhitelistLabels: {}
 
 dapWorkerReplicaCount: 1


### PR DESCRIPTION
## Summary

Changes the `catalyst` chart to accept the container image as separate `image.repository` and `image.tag` values, matching the `atomic-app` chart, instead of a single combined `image: "repo:tag"` string.

## Breaking change

Existing values files that set the combined string form (`image: "repo:tag"`) will **no longer render** — a string can't be indexed by `.repository`/`.tag`. Chart version bumped `2.6.0` → `3.0.0` to reflect this.

## Migration

Update your values files (and any ArgoCD Application / CD pipeline that sets the image) before upgrading to chart `3.0.0`.

**Before (chart ≤ 2.x):**

```yaml
image: myrepo/catalyst:1.2.3
```

**After (chart ≥ 3.0.0):**

```yaml
image:
  repository: myrepo/catalyst
  tag: "1.2.3"
```

Notes:
- Split the single string on the last `:` — everything before is `repository`, everything after is `tag`.
- `tag` is required. There is no `appVersion` fallback, so a missing/empty `tag` renders `repository:` (an invalid image reference). Always set it explicitly.
- If you set the image via `--set` or a CD pipeline, change `--set image=repo:tag` to `--set image.repository=repo --set image.tag=tag`.
- The `dnsSidecar` and `scheduledScaling` image settings are unchanged.

## Details

- All Catalyst image references (app, worker, lead-worker, dap-worker deployments + their `check-migrations` init containers, migrations Job, and cronjobs) now render `"{{ .Values.image.repository }}:{{ .Values.image.tag }}"`.
- Also guards the `elasticsearchWhitelistLabels` label block with an `if` so an empty map (the default) no longer emits invalid YAML — this fixes `helm lint`, which previously failed on the default values.

## Verification

- `helm lint .` passes (was failing before this change).
- `helm template` renders correct images with the split form, and `elasticsearchWhitelistLabels` renders correctly both empty and populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)